### PR TITLE
Re-requesting, with much simplified changes

### DIFF
--- a/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
+++ b/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
@@ -1,6 +1,6 @@
 package Geometry::AffineTransform;
 
-our $VERSION = '1.4';
+our $VERSION = '1.5';
 
 use strict;
 use warnings;
@@ -183,9 +183,8 @@ Takes the six specifiable parts of the 3x3 transformation matrix.
 sub concatenate_matrix_2x3 {
 	my $self = shift;
 	my ($m11, $m12, $m21, $m22, $tx, $ty) = @_;
-	my $a = [$self->matrix_2x3()];
 	my $b = [$m11, $m12, $m21, $m22, $tx, $ty];
-	return $self->set_matrix_2x3($self->matrix_multiply($a, $b));
+	return $self->set_matrix_2x3($self->_matrix_multiply($b));
 }
 
 
@@ -370,11 +369,10 @@ sub matrix {
 
 
 
-
 # a simplified multiply that assumes the fixed 0 0 1 third column
-sub matrix_multiply {
+sub _matrix_multiply {
 	my $self = shift;
-	my ($a, $b) = @_;
+	my ($b) = @_;
 
 # 	a11 a12 0
 # 	a21 a22 0
@@ -384,7 +382,7 @@ sub matrix_multiply {
 # 	b21 b22 0
 # 	b31 b32 1
 
-	my ($a11, $a12, $a21, $a22, $a31, $a32) = @$a;
+	my ($a11, $a12, $a21, $a22, $a31, $a32) = $self->matrix_2x3();
 	my ($b11, $b12, $b21, $b22, $b31, $b32) = @$b;
 
 	return

--- a/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
+++ b/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
@@ -171,9 +171,15 @@ sub transform {
 
 
 
+=head2 concatenate_matrix_2x3 
 
-# concatenate another transformation matrix to the current state.
-# Takes the six specifiable parts of the 3x3 transformation matrix.
+Concatenate another transformation matrix to the current state.
+Takes the six specifiable parts of the 3x3 transformation matrix.
+
+	my $translated = $t->concatenate_matrix_2x3(1, 0, 0, 1, $horiz, $vert);
+
+=cut
+
 sub concatenate_matrix_2x3 {
 	my $self = shift;
 	my ($m11, $m12, $m21, $m22, $tx, $ty) = @_;
@@ -294,6 +300,16 @@ sub rotate {
 }
 
 
+=head2 matrix_2x3
+
+Returns the current value of the 3 x 3 transformation matrix (leaving off
+the third, fixed column) as a 6-element list:
+
+    my ($m11, $m12,
+        $m21, $m22,
+        $tx,  $ty ) = $t->matrix_2x3();
+
+=cut
 
 # returns the 6 specifiable parts of the transformation matrix
 sub matrix_2x3 {
@@ -302,12 +318,29 @@ sub matrix_2x3 {
 }
 
 
-# returns the determinant of the matrix
+=head2 determinant
+
+Returns the determinant of the matrix.  See the Resources section, below, for
+help understanding matrix determinants.
+
+    my $det = $t->determinant();
+
+=cut
+
 sub determinant {
 	my $self = shift;
 	return $self->{m11} * $self->{m22} - $self->{m12} * $self->{m21};
 }
 
+
+
+=head2 set_matrix_2x3
+
+Sets the current value of the transformation matrix, as a 6-element list:
+
+    $t->set_matrix_2x3($m11, $m12, $m21, $m22, $tx,  $ty );
+
+=cut
 
 # sets the 6 specifiable parts of the transformation matrix
 sub set_matrix_2x3 {

--- a/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
+++ b/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
@@ -84,11 +84,10 @@ In other words, invoking the constructor without arguments is equivalent to this
 =cut
 
 sub new {
-	my $self = shift;
+	my $class = shift;
 	my (%args) = @_;
 
-	my $class = ref($self) || $self;
-	$self = bless {m11 => 1, m12 => 0, m21 => 0, m22 => 1, tx => 0, ty => 0, %args}, $class;
+	my $self = bless {m11 => 1, m12 => 0, m21 => 0, m22 => 1, tx => 0, ty => 0, %args}, $class;
 #	$self->init();
 	Hash::Util::lock_keys(%$self);
 
@@ -111,7 +110,7 @@ Returns a clone of the instance.
 
 sub clone {
 	my $self = shift;
-	return $self->new()->set_matrix_2x3($self->matrix_2x3());
+	return ref($self)->new()->set_matrix_2x3($self->matrix_2x3());
 }
 
 

--- a/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
+++ b/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
@@ -183,9 +183,8 @@ Takes the six specifiable parts of the 3x3 transformation matrix.
 sub concatenate_matrix_2x3 {
 	my $self = shift;
 	my ($m11, $m12, $m21, $m22, $tx, $ty) = @_;
-	my $a = [$self->matrix_2x3()];
 	my $b = [$m11, $m12, $m21, $m22, $tx, $ty];
-	return $self->set_matrix_2x3($self->matrix_multiply($a, $b));
+	return $self->set_matrix_2x3($self->_matrix_multiply($b));
 }
 
 
@@ -370,11 +369,10 @@ sub matrix {
 
 
 
-
 # a simplified multiply that assumes the fixed 0 0 1 third column
-sub matrix_multiply {
+sub _matrix_multiply {
 	my $self = shift;
-	my ($a, $b) = @_;
+	my ($b) = @_;
 
 # 	a11 a12 0
 # 	a21 a22 0
@@ -384,7 +382,7 @@ sub matrix_multiply {
 # 	b21 b22 0
 # 	b31 b32 1
 
-	my ($a11, $a12, $a21, $a22, $a31, $a32) = @$a;
+	my ($a11, $a12, $a21, $a22, $a31, $a32) = $self->matrix_2x3();
 	my ($b11, $b12, $b21, $b22, $b31, $b32) = @$b;
 
 	return

--- a/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
+++ b/Geometry-AffineTransform/lib/Geometry/AffineTransform.pm
@@ -200,7 +200,7 @@ sub concatenate {
 	my $self = shift;
 	my @transforms = @_;
 	foreach my $t (@transforms) {
-		croak "Expecting argument of type Geometry::AffineTransform" unless (ref $t);
+		croak "Expecting argument of type Geometry::AffineTransform" unless (ref $t eq ref $self);
 		$self->concatenate_matrix_2x3($t->matrix_2x3()) ;
 	}
 	return $self;

--- a/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
+++ b/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
@@ -190,7 +190,8 @@ sub matrix_multiply : Test(1) {
 #	3 * 1 + 4 * 3 + 0 * 5 = 15    3 * 2 + 4 * 4 + 0 * 6 = 22    3 * 0 + 4 * 0 + 0 * 1 = 0
 #	5 * 1 + 6 * 3 + 1 * 5 = 28    5 * 2 + 6 * 4 + 1 * 6 = 40    5 * 0 + 6 * 0 + 1 * 1 = 1
 	
-	my @result = Geometry::AffineTransform->matrix_multiply([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]);
+	my $t = Geometry::AffineTransform->new()->set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	my @result = $t->_matrix_multiply( [1, 2, 3, 4, 5, 6]);
 	is_deeply(\@result, [7, 10, 15, 22, 28, 40]);
 #	diag(Data::Dumper->Dump([\@result]));
 

--- a/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
+++ b/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
@@ -105,7 +105,7 @@ sub concatenate_matrix_2x3 : Test(2) {
 
 
 
-sub concatenate : Test(1) {
+sub concatenate : Test(2) {
 	my $self = shift @_;
 	my $t = Geometry::AffineTransform->new();
 	$t->set_matrix_2x3(1, 2, 3, 4, 5, 6);
@@ -113,6 +113,9 @@ sub concatenate : Test(1) {
 	$t2->set_matrix_2x3(1, 2, 3, 4, 5, 6);
 	$t->concatenate($t2);
 	is_deeply([$t->matrix_2x3()], [7, 10, 15, 22, 28, 40]);
+
+	eval { $t->concatenate($self) };
+	ok($@, "Geometry::AffineTransform::concatenate checks for valid object");
 }
 
 

--- a/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
+++ b/Geometry-AffineTransform/t/lib/Geometry/AffineTransform/Test.pm
@@ -86,10 +86,10 @@ sub rotate : Test(5) {
 sub matrix_2x3 : Test(4) {
 	my $self = shift @_;
 	my $t = Geometry::AffineTransform->new();
-	is_deeply([$t->matrix_2x3()], [1, 0, 0, 1, 0, 0]);
+	is_deeply([$t->_matrix_2x3()], [1, 0, 0, 1, 0, 0]);
 
-	is($t->set_matrix_2x3(1, 2, 3, 4, 5, 6), $t, "set_matrix_2x3");
-	is_deeply([$t->matrix_2x3()], [1, 2, 3, 4, 5, 6]);
+	is($t->_set_matrix_2x3(1, 2, 3, 4, 5, 6), $t, "_set_matrix_2x3");
+	is_deeply([$t->_matrix_2x3()], [1, 2, 3, 4, 5, 6]);
 	is_deeply([$t->matrix()], [1, 2, 0, 3, 4, 0, 5, 6, 1]);
 }
 
@@ -98,9 +98,9 @@ sub matrix_2x3 : Test(4) {
 sub concatenate_matrix_2x3 : Test(2) {
 	my $self = shift @_;
 	my $t = Geometry::AffineTransform->new();
-	$t->set_matrix_2x3(1, 2, 3, 4, 5, 6);
-	is($t->concatenate_matrix_2x3(1, 2, 3, 4, 5, 6), $t, "concatenate_matrix_2x3()");
-	is_deeply([$t->matrix_2x3()], [7, 10, 15, 22, 28, 40]);
+	$t->_set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	is($t->_concatenate_matrix_2x3(1, 2, 3, 4, 5, 6), $t, "_concatenate_matrix_2x3()");
+	is_deeply([$t->_matrix_2x3()], [7, 10, 15, 22, 28, 40]);
 }
 
 
@@ -108,11 +108,11 @@ sub concatenate_matrix_2x3 : Test(2) {
 sub concatenate : Test(2) {
 	my $self = shift @_;
 	my $t = Geometry::AffineTransform->new();
-	$t->set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	$t->_set_matrix_2x3(1, 2, 3, 4, 5, 6);
 	my $t2 = Geometry::AffineTransform->new();
-	$t2->set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	$t2->_set_matrix_2x3(1, 2, 3, 4, 5, 6);
 	$t->concatenate($t2);
-	is_deeply([$t->matrix_2x3()], [7, 10, 15, 22, 28, 40]);
+	is_deeply([$t->_matrix_2x3()], [7, 10, 15, 22, 28, 40]);
 
 	eval { $t->concatenate($self) };
 	ok($@, "Geometry::AffineTransform::concatenate checks for valid object");
@@ -165,12 +165,12 @@ sub rect_dimensions {
 
 sub clone : Test(3) {
 	my $self = shift @_;
-	my $t = Geometry::AffineTransform->new()->set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	my $t = Geometry::AffineTransform->new()->_set_matrix_2x3(1, 2, 3, 4, 5, 6);
 	my $t2 = $t->clone();
-	is_deeply([$t2->matrix_2x3()], [1, 2, 3, 4, 5, 6]);
-	$t->set_matrix_2x3(reverse 1, 2, 3, 4, 5, 6);
-	is_deeply([$t->matrix_2x3()], [reverse 1, 2, 3, 4, 5, 6]);
-	is_deeply([$t2->matrix_2x3()], [1, 2, 3, 4, 5, 6]);
+	is_deeply([$t2->_matrix_2x3()], [1, 2, 3, 4, 5, 6]);
+	$t->_set_matrix_2x3(reverse 1, 2, 3, 4, 5, 6);
+	is_deeply([$t->_matrix_2x3()], [reverse 1, 2, 3, 4, 5, 6]);
+	is_deeply([$t2->_matrix_2x3()], [1, 2, 3, 4, 5, 6]);
 	
 }
 
@@ -190,7 +190,8 @@ sub matrix_multiply : Test(1) {
 #	3 * 1 + 4 * 3 + 0 * 5 = 15    3 * 2 + 4 * 4 + 0 * 6 = 22    3 * 0 + 4 * 0 + 0 * 1 = 0
 #	5 * 1 + 6 * 3 + 1 * 5 = 28    5 * 2 + 6 * 4 + 1 * 6 = 40    5 * 0 + 6 * 0 + 1 * 1 = 1
 	
-	my @result = Geometry::AffineTransform->matrix_multiply([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6]);
+	my $t = Geometry::AffineTransform->new()->_set_matrix_2x3(1, 2, 3, 4, 5, 6);
+	my @result = $t->_matrix_multiply( [1, 2, 3, 4, 5, 6]);
 	is_deeply(\@result, [7, 10, 15, 22, 28, 40]);
 #	diag(Data::Dumper->Dump([\@result]));
 


### PR DESCRIPTION
I agree with your points, here I've removed the extra POD and just renamed the internal functions with an underscore.  Updated the version number because new() can't be called as a instance method anymore.

I tried a rebase to squash my changes, but I don't think it worked properly as they had already been pushed to github.  If there's a way to merge the final change without the intermediate ones, that would be preferable, I think.

Oh -- I left determinant as a public method, meant to talk to you about that first; I only did that because it does have geometric meaning that could be useful.

Thanks, Marc!
